### PR TITLE
Adds more aggressive lookup of `requires_dist`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Parsley==1.3
 pep508-parser==2019.3
+pkginfo==1.5.0.1


### PR DESCRIPTION
Hello!

Thank you for the useful package. We had some issues, however, with it not being able to 
resolve dependencies for some packages. Upon further investigation, it seems that the json
reply from PYPI does not contain a `requires_dist` for all packages (see https://pypi.org/pypi/sentry-sdk).

I think this patch addresses this issue. Please have a look at it and let me know if any changes ought to be made!