### PR TITLE
Strip quote from license when translating

### DIFF
--- a/pipoe/pipoe.py
+++ b/pipoe/pipoe.py
@@ -122,7 +122,7 @@ def package_to_bb_name(package):
 
 def translate_license(license, default_license):
     try:
-        return licenses.LICENSES[license]
+        return licenses.LICENSES[license.strip("'").strip('"')]
     except:
         if default_license:
             return default_license


### PR DESCRIPTION
Some packages (PyMySQL for example) quote the license, meaning it can't be translated when it should be.