### PR TITLE
Map "MPL 2.0" to MPL-2.0

### DIFF
--- a/pipoe/licenses.py
+++ b/pipoe/licenses.py
@@ -137,6 +137,7 @@ LICENSES = {
     "MIT License": "MIT",
     "MIT license": "MIT",
     "MIT/X11": "MIT",
+    "MPL 2.0": "MPL-2.0",
     "MPL v2": "MPL-2.0",
     "MPL-1.0": "MPL-1.0",
     "MPL-1.1": "MPL-1.1",


### PR DESCRIPTION
I had a package (bdict) which specified `"MPL 2.0"` as the license and pipoe didnt know how to map it, but this should fix it